### PR TITLE
Fix getting the zero Matsubara component in TRIQS 3.3

### DIFF
--- a/python/som/som.py
+++ b/python/som/som.py
@@ -175,7 +175,7 @@ def estimate_boson_corr_spectrum_norms(chi: Gf) -> List[float]:
     N = chi.target_shape[0]
 
     if isinstance(chi.mesh, MeshImFreq):
-        W0 = list(chi.mesh.values()).index(0j)
+        W0 = next(mp.data_index for mp in chi.mesh if mp.index == 0)
         return np.pi * np.array([chi.data[W0, n, n].real for n in range(N)])
 
     elif isinstance(chi.mesh, MeshImTime):


### PR DESCRIPTION
I encountered this error while I was running the tutorial for the optical conductivity case, where estimate_boson_corr_spectrum_norms() is used. I was using TRIQS 3.3.

It seems that in TRIQS 3.3, Matsubara frequency objects are no longer implicitly converted to complex here, therefore .index(0j) fails.

I propose this fix, which is instead based on integer comparison of the Matsubara index. I checked that it also works on TRIQS 3.2.

@Thoemi09